### PR TITLE
Withdrawal Cooldown Wallet Smart Contract

### DIFF
--- a/verbose_contracts/Clarinet.toml
+++ b/verbose_contracts/Clarinet.toml
@@ -19,6 +19,11 @@ epoch = 2.5
 path = 'contracts/result_finalization.clar'
 clarity_version = 2
 epoch = 2.5
+
+[contracts.withdrawal_cooldown_wallet]
+path = 'contracts/withdrawal_cooldown_wallet.clar'
+clarity_version = 2
+epoch = 2.5
 [repl.analysis]
 passes = ['check_checker']
 

--- a/verbose_contracts/contracts/withdrawal_cooldown_wallet.clar
+++ b/verbose_contracts/contracts/withdrawal_cooldown_wallet.clar
@@ -108,3 +108,17 @@
   )
 )
 
+;; Set cooldown period (only contract owner)
+(define-public (set-cooldown-period (new-cooldown uint))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-OWNER-ONLY)
+    (asserts! (> new-cooldown u0) ERR-INVALID-COOLDOWN)
+    (var-set cooldown-period new-cooldown)
+    (ok new-cooldown)
+  )
+)
+
+;; Get contract STX balance
+(define-read-only (get-contract-balance)
+  (stx-get-balance (as-contract tx-sender))
+)

--- a/verbose_contracts/contracts/withdrawal_cooldown_wallet.clar
+++ b/verbose_contracts/contracts/withdrawal_cooldown_wallet.clar
@@ -108,17 +108,3 @@
   )
 )
 
-;; Set cooldown period (only contract owner)
-(define-public (set-cooldown-period (new-cooldown uint))
-  (begin
-    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-OWNER-ONLY)
-    (asserts! (> new-cooldown u0) ERR-INVALID-COOLDOWN)
-    (var-set cooldown-period new-cooldown)
-    (ok new-cooldown)
-  )
-)
-
-;; Get contract STX balance
-(define-read-only (get-contract-balance)
-  (stx-get-balance (as-contract tx-sender))
-)

--- a/verbose_contracts/contracts/withdrawal_cooldown_wallet.clar
+++ b/verbose_contracts/contracts/withdrawal_cooldown_wallet.clar
@@ -1,0 +1,124 @@
+;; Withdrawal Cooldown Wallet Smart Contract
+;; This contract implements a wallet with cooldown periods between withdrawals
+
+;; Constants
+(define-constant CONTRACT-OWNER tx-sender)
+(define-constant ERR-OWNER-ONLY (err u100))
+(define-constant ERR-INSUFFICIENT-BALANCE (err u101))
+(define-constant ERR-COOLDOWN-NOT-PASSED (err u102))
+(define-constant ERR-INVALID-AMOUNT (err u103))
+(define-constant ERR-INVALID-COOLDOWN (err u104))
+
+;; Default cooldown period (24 hours in blocks, assuming ~10 minute blocks)
+(define-constant DEFAULT-COOLDOWN-BLOCKS u144)
+
+;; Data Variables
+(define-data-var cooldown-period uint DEFAULT-COOLDOWN-BLOCKS)
+
+;; Data Maps
+;; Track user balances
+(define-map user-balances principal uint)
+
+;; Track last withdrawal time for each user
+(define-map last-withdrawal-time principal uint)
+
+;; Read-only functions
+(define-read-only (get-balance (user principal))
+  (default-to u0 (map-get? user-balances user))
+)
+
+(define-read-only (get-last-withdrawal-time (user principal))
+  (default-to u0 (map-get? last-withdrawal-time user))
+)
+
+(define-read-only (get-cooldown-period)
+  (var-get cooldown-period)
+)
+
+(define-read-only (can-withdraw (user principal))
+  (let ((last-withdrawal (get-last-withdrawal-time user))
+        (current-block block-height)
+        (cooldown (var-get cooldown-period)))
+    (>= (- current-block last-withdrawal) cooldown)
+  )
+)
+
+(define-read-only (blocks-until-next-withdrawal (user principal))
+  (let ((last-withdrawal (get-last-withdrawal-time user))
+        (current-block block-height)
+        (cooldown (var-get cooldown-period))
+        (blocks-passed (- current-block last-withdrawal)))
+    (if (>= blocks-passed cooldown)
+        u0
+        (- cooldown blocks-passed)
+    )
+  )
+)
+
+;; Public functions
+
+;; Deposit STX into the wallet
+(define-public (deposit (amount uint))
+  (begin
+    (asserts! (> amount u0) ERR-INVALID-AMOUNT)
+    (try! (stx-transfer? amount tx-sender (as-contract tx-sender)))
+    (let ((current-balance (get-balance tx-sender)))
+      (map-set user-balances tx-sender (+ current-balance amount))
+      (ok amount)
+    )
+  )
+)
+
+;; Withdraw STX from the wallet (with cooldown check)
+(define-public (withdraw (amount uint))
+  (let ((user-balance (get-balance tx-sender)))
+    ;; Check if amount is valid
+    (asserts! (> amount u0) ERR-INVALID-AMOUNT)
+    ;; Check if user has sufficient balance
+    (asserts! (>= user-balance amount) ERR-INSUFFICIENT-BALANCE)
+    ;; Check if cooldown period has passed
+    (asserts! (can-withdraw tx-sender) ERR-COOLDOWN-NOT-PASSED)
+    
+    ;; Perform withdrawal
+    (try! (as-contract (stx-transfer? amount tx-sender tx-sender)))
+    
+    ;; Update user balance
+    (map-set user-balances tx-sender (- user-balance amount))
+    
+    ;; Update last withdrawal time
+    (map-set last-withdrawal-time tx-sender block-height)
+    
+    (ok amount)
+  )
+)
+
+;; Emergency withdraw (only for contract owner, bypasses cooldown)
+(define-public (emergency-withdraw (user principal) (amount uint))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-OWNER-ONLY)
+    (let ((user-balance (get-balance user)))
+      (asserts! (> amount u0) ERR-INVALID-AMOUNT)
+      (asserts! (>= user-balance amount) ERR-INSUFFICIENT-BALANCE)
+      
+      (try! (as-contract (stx-transfer? amount user tx-sender)))
+      (map-set user-balances user (- user-balance amount))
+      
+      (ok amount)
+    )
+  )
+)
+
+;; Set cooldown period (only contract owner)
+(define-public (set-cooldown-period (new-cooldown uint))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-OWNER-ONLY)
+    (asserts! (> new-cooldown u0) ERR-INVALID-COOLDOWN)
+    (var-set cooldown-period new-cooldown)
+    (ok new-cooldown)
+  )
+)
+
+;; Get contract STX balance
+(define-read-only (get-contract-balance)
+  (stx-get-balance (as-contract tx-sender))
+)

--- a/verbose_contracts/tests/withdrawal_cooldown_wallet.test.ts
+++ b/verbose_contracts/tests/withdrawal_cooldown_wallet.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
---

# Withdrawal Cooldown Wallet Smart Contract

This smart contract is written in **Clarity** and implements a **wallet with a cooldown period** between withdrawals. The primary goal is to enforce a waiting period between successive withdrawals by the same user to enhance security and reduce abuse.

---

## **Features**

* **Deposit STX:** Users can deposit STX into the contract and have their balances tracked.
* **Cooldown-based Withdrawals:** Users can only withdraw funds after a specified cooldown period has passed since their last withdrawal.
* **Customizable Cooldown:** Contract owner can set the cooldown period (in blocks).
* **Emergency Withdrawals:** The contract owner can bypass the cooldown and withdraw on behalf of any user.
* **Balance Tracking:** Individual user balances and contract balance are stored and retrievable.
* **Read-only helper functions:** Retrieve balances, last withdrawal times, remaining cooldown time, and cooldown status.

---

## **Constants**

* `CONTRACT-OWNER`: The contract deployer.
* `DEFAULT-COOLDOWN-BLOCKS`: Default cooldown (144 blocks ≈ 24 hours assuming 10-minute blocks).
* Error codes:

  * `ERR-OWNER-ONLY` (u100) – Only the contract owner can perform this action.
  * `ERR-INSUFFICIENT-BALANCE` (u101) – User does not have enough funds.
  * `ERR-COOLDOWN-NOT-PASSED` (u102) – Withdrawal attempted before cooldown expired.
  * `ERR-INVALID-AMOUNT` (u103) – Invalid deposit/withdrawal amount (must be > 0).
  * `ERR-INVALID-COOLDOWN` (u104) – Invalid cooldown value (must be > 0).

---

## **Data Structures**

* `user-balances` (map): Tracks balances per user principal.
* `last-withdrawal-time` (map): Tracks last withdrawal block height per user.
* `cooldown-period` (var): Stores the cooldown period (uint).

---

## **Read-only Functions**

1. **`get-balance(user)`**: Returns the STX balance for the specified user.
2. **`get-last-withdrawal-time(user)`**: Returns the last withdrawal block height for the user.
3. **`get-cooldown-period()`**: Returns the current cooldown period in blocks.
4. **`can-withdraw(user)`**: Returns `true` if the user is allowed to withdraw.
5. **`blocks-until-next-withdrawal(user)`**: Returns the remaining blocks until a user can withdraw.
6. **`get-contract-balance()`**: Returns the STX balance held by the contract.

---

## **Public Functions**

1. **`deposit(amount)`**

   * Transfers `amount` STX from `tx-sender` to the contract.
   * Updates the user’s balance.
   * Fails if `amount <= 0`.

2. **`withdraw(amount)`**

   * Allows users to withdraw STX if:

     * They have sufficient balance.
     * Cooldown period has passed.
   * Updates user’s balance and last withdrawal time.
   * Fails if `amount <= 0`, insufficient balance, or cooldown not passed.

3. **`emergency-withdraw(user, amount)`**

   * **Only the contract owner** can call.
   * Withdraws on behalf of a user bypassing cooldown.
   * Fails if amount is invalid or exceeds the user’s balance.

4. **`set-cooldown-period(new-cooldown)`**

   * **Only the contract owner** can call.
   * Sets a new cooldown period (must be > 0).

---

## **Deployment & Usage Notes**

* The contract assumes **\~10-minute block times**, so the default cooldown of `u144` ≈ 24 hours.
* Only the **contract deployer** (owner) can change cooldown or perform emergency withdrawals.
* Balances are maintained internally and must be deposited first before withdrawing.

---

## **Security Considerations**

* Users should trust the contract owner since they have the ability to emergency-withdraw from user balances.
* Make sure to audit the deployment address and owner’s authority before using in production.

---