### PR TITLE
Pause Functionality with Multi-Send Smart Contract (STX)

### DIFF
--- a/verbose_contracts/Clarinet.toml
+++ b/verbose_contracts/Clarinet.toml
@@ -15,6 +15,11 @@ path = 'contracts/file_rating.clar'
 clarity_version = 2
 epoch = 2.5
 
+[contracts.multi_send_with_pause_functionality]
+path = 'contracts/multi_send_with_pause_functionality.clar'
+clarity_version = 2
+epoch = 2.5
+
 [contracts.result_finalization]
 path = 'contracts/result_finalization.clar'
 clarity_version = 2

--- a/verbose_contracts/contracts/multi_send_with_pause_functionality.clar
+++ b/verbose_contracts/contracts/multi_send_with_pause_functionality.clar
@@ -1,0 +1,216 @@
+;; Multi-Send Contract with Pause Functionality
+;; Allows batch STX transfers with emergency pause controls
+
+;; Constants
+(define-constant contract-owner tx-sender)
+(define-constant err-owner-only (err u100))
+(define-constant err-contract-paused (err u101))
+(define-constant err-insufficient-balance (err u102))
+(define-constant err-invalid-recipient (err u103))
+(define-constant err-invalid-amount (err u104))
+(define-constant err-transfer-failed (err u105))
+(define-constant err-empty-recipients (err u106))
+
+;; Data Variables
+(define-data-var contract-paused bool false)
+(define-data-var total-transfers uint u0)
+
+;; Data Maps
+(define-map authorized-operators principal bool)
+
+;; Private Functions
+
+;; Check if contract is paused
+(define-private (is-paused)
+  (var-get contract-paused)
+)
+
+;; Check if caller is contract owner
+(define-private (is-owner (caller principal))
+  (is-eq caller contract-owner)
+)
+
+;; Check if caller is authorized operator
+(define-private (is-authorized-operator (caller principal))
+  (default-to false (map-get? authorized-operators caller))
+)
+
+;; Check if caller can perform admin functions
+(define-private (can-admin (caller principal))
+  (or (is-owner caller) (is-authorized-operator caller))
+)
+
+;; Validate transfer parameters
+(define-private (validate-transfer (recipient principal) (amount uint))
+  (and 
+    (> amount u0)
+    (not (is-eq recipient tx-sender))
+  )
+)
+
+;; Execute single STX transfer
+(define-private (execute-transfer (recipient principal) (amount uint))
+  (begin
+    (asserts! (validate-transfer recipient amount) err-invalid-recipient)
+    (match (stx-transfer? amount tx-sender recipient)
+      success (ok true)
+      error err-transfer-failed
+    )
+  )
+)
+
+;; Process single transfer for fold operation
+(define-private (process-single-transfer (transfer-data {recipient: principal, amount: uint}) (previous-result (response uint uint)))
+  (match previous-result
+    prev-success (match (execute-transfer (get recipient transfer-data) (get amount transfer-data))
+                   transfer-success (ok prev-success)
+                   transfer-error (err transfer-error))
+    prev-error (err prev-error)
+  )
+)
+
+;; Read-Only Functions
+
+;; Get contract pause status
+(define-read-only (get-pause-status)
+  (var-get contract-paused)
+)
+
+;; Get total number of transfers processed
+(define-read-only (get-total-transfers)
+  (var-get total-transfers)
+)
+
+;; Check if address is authorized operator
+(define-read-only (is-operator (operator principal))
+  (default-to false (map-get? authorized-operators operator))
+)
+
+;; Get contract owner
+(define-read-only (get-contract-owner)
+  contract-owner
+)
+
+;; Check if caller can perform admin operations
+(define-read-only (can-perform-admin (caller principal))
+  (can-admin caller)
+)
+
+;; Public Functions
+
+;; Pause the contract (owner/operator only)
+(define-public (pause-contract)
+  (begin
+    (asserts! (can-admin tx-sender) err-owner-only)
+    (var-set contract-paused true)
+    (ok true)
+  )
+)
+
+;; Unpause the contract (owner/operator only)
+(define-public (unpause-contract)
+  (begin
+    (asserts! (can-admin tx-sender) err-owner-only)
+    (var-set contract-paused false)
+    (ok true)
+  )
+)
+
+;; Add authorized operator (owner only)
+(define-public (add-operator (operator principal))
+  (begin
+    (asserts! (is-owner tx-sender) err-owner-only)
+    (map-set authorized-operators operator true)
+    (ok true)
+  )
+)
+
+;; Remove authorized operator (owner only)
+(define-public (remove-operator (operator principal))
+  (begin
+    (asserts! (is-owner tx-sender) err-owner-only)
+    (map-delete authorized-operators operator)
+    (ok true)
+  )
+)
+
+;; Multi-send STX to multiple recipients
+(define-public (multi-send-stx (recipients (list 50 {recipient: principal, amount: uint})))
+  (let (
+    (total-amount (fold + (map get-amount recipients) u0))
+    (recipient-count (len recipients))
+  )
+    ;; Check if contract is paused
+    (asserts! (not (is-paused)) err-contract-paused)
+    
+    ;; Check if recipients list is not empty
+    (asserts! (> recipient-count u0) err-empty-recipients)
+    
+    ;; Check if sender has sufficient balance
+    (asserts! (>= (stx-get-balance tx-sender) total-amount) err-insufficient-balance)
+    
+    ;; Process all transfers using fold
+    (match (fold process-single-transfer recipients (ok u0))
+      success (begin
+        ;; Update total transfers counter
+        (var-set total-transfers (+ (var-get total-transfers) recipient-count))
+        (ok {
+          total-sent: total-amount,
+          recipients-count: recipient-count,
+          transfer-id: (var-get total-transfers)
+        })
+      )
+      error (err error)
+    )
+  )
+)
+
+;; Helper function to extract amount from recipient tuple
+(define-private (get-amount (recipient-data {recipient: principal, amount: uint}))
+  (get amount recipient-data)
+)
+
+;; Emergency withdrawal function (owner only) - for stuck funds
+(define-public (emergency-withdraw (amount uint))
+  (begin
+    (asserts! (is-owner tx-sender) err-owner-only)
+    (asserts! (is-paused) err-contract-paused) ;; Can only withdraw when paused
+    (stx-transfer? amount (as-contract tx-sender) contract-owner)
+  )
+)
+
+;; Multi-send with custom memo
+(define-public (multi-send-stx-with-memo 
+  (recipients (list 50 {recipient: principal, amount: uint})) 
+  (memo (buff 34)))
+  (let (
+    (total-amount (fold + (map get-amount recipients) u0))
+    (recipient-count (len recipients))
+  )
+    ;; Check if contract is paused
+    (asserts! (not (is-paused)) err-contract-paused)
+    
+    ;; Check if recipients list is not empty
+    (asserts! (> recipient-count u0) err-empty-recipients)
+    
+    ;; Check if sender has sufficient balance
+    (asserts! (>= (stx-get-balance tx-sender) total-amount) err-insufficient-balance)
+    
+    ;; Process all transfers using fold
+    (match (fold process-single-transfer recipients (ok u0))
+      success (begin
+        ;; Update total transfers counter
+        (var-set total-transfers (+ (var-get total-transfers) recipient-count))
+        ;; Print memo for transaction tracking
+        (print {memo: memo, batch-id: (var-get total-transfers)})
+        (ok {
+          total-sent: total-amount,
+          recipients-count: recipient-count,
+          transfer-id: (var-get total-transfers),
+          memo: memo
+        })
+      )
+      error (err error)
+    )
+  )
+)

--- a/verbose_contracts/tests/multi_send_with_pause_functionality.test.ts
+++ b/verbose_contracts/tests/multi_send_with_pause_functionality.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
---

# 📨 Multi-Send STX Contract with Pause Functionality

A Clarity smart contract that enables **batch STX transfers** to multiple recipients in a single transaction. It includes **emergency pause functionality**, **operator management**, and **custom memos** for transaction tracking.

---

## 🚀 Features

* **Batch STX Transfers** – Send STX to up to **50 recipients** at once.
* **Pause/Unpause Controls** – Temporarily stop all transfers in case of emergencies.
* **Operator System** – Owner can delegate operator privileges to other accounts.
* **Custom Memos** – Attach metadata (up to 34 bytes) to bulk transactions.
* **Emergency Withdraw** – Owner can recover stuck funds when the contract is paused.
* **Transfer Tracking** – Keeps a counter of total processed transfers.

---

## ⚙️ How It Works

1. **Sender prepares a batch transfer**

   * Defines a list of `{ recipient, amount }` objects (up to 50).
   * Calls `multi-send-stx` or `multi-send-stx-with-memo`.

2. **Contract validates and executes**

   * Checks pause status.
   * Ensures sender has sufficient balance.
   * Transfers STX to all recipients.
   * Updates `total-transfers` counter.

3. **Admin controls**

   * Owner and authorized operators can pause/unpause the contract.
   * Only the owner can add/remove operators.
   * Emergency withdrawals only allowed when paused.

---

## 📜 Functions

### 🔹 Public Functions

* `multi-send-stx(recipients)`
  Bulk send STX to multiple recipients.

* `multi-send-stx-with-memo(recipients, memo)`
  Same as above, but attaches a **memo** for transaction tracking.

* `pause-contract()`
  Pause transfers (owner/operator only).

* `unpause-contract()`
  Resume transfers (owner/operator only).

* `add-operator(operator)`
  Add a new authorized operator (owner only).

* `remove-operator(operator)`
  Remove an operator (owner only).

* `emergency-withdraw(amount)`
  Withdraw STX to owner account if stuck (only when paused).

---

### 🔹 Read-Only Functions

* `get-pause-status()` → `bool`
  Returns whether the contract is paused.

* `get-total-transfers()` → `uint`
  Returns total number of transfers processed.

* `is-operator(operator)` → `bool`
  Checks if an address is an authorized operator.

* `get-contract-owner()` → `principal`
  Returns contract owner.

* `can-perform-admin(caller)` → `bool`
  Checks if a caller has admin privileges.

---

### 🔹 Events

* **Multi-Send with Memo** prints:

  ```clarity
  { memo: (buff 34), batch-id: uint }
  ```

---

## 🛡️ Security

* **Emergency Pause** – Protects users in case of exploits.
* **Role-based Access Control** – Only owner can manage operators.
* **Validation Checks** – Prevents invalid recipients, empty batches, or insufficient balances.
* **Withdrawal Safety** – Owner can only withdraw funds when contract is paused.

---

## 🔑 Example Usage

### ✅ Batch Send STX

```clarity
(contract-call? .multi-send multi-send-stx
  (list 
    { recipient: 'ST123...', amount: u1000 } 
    { recipient: 'ST456...', amount: u2000 }
  )
)
```

### ✅ Batch Send with Memo

```clarity
(contract-call? .multi-send multi-send-stx-with-memo
  (list 
    { recipient: 'ST123...', amount: u1000 } 
    { recipient: 'ST456...', amount: u2000 }
  )
  0x48656c6c6f20576f726c64 ;; "Hello World" in hex
)
```

### ✅ Pause Contract

```clarity
(contract-call? .multi-send pause-contract)
```

---

## ⚖️ License

This project is licensed under the **MIT License**.

```
MIT License

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
SOFTWARE.
```

---