### PR TITLE
Immutable Storage Clarity Smart Contract

### DIFF
--- a/verbose_contracts/Clarinet.toml
+++ b/verbose_contracts/Clarinet.toml
@@ -15,6 +15,11 @@ path = 'contracts/file_rating.clar'
 clarity_version = 2
 epoch = 2.5
 
+[contracts.immutable_storage]
+path = 'contracts/immutable_storage.clar'
+clarity_version = 2
+epoch = 2.5
+
 [contracts.multi_send_with_pause_functionality]
 path = 'contracts/multi_send_with_pause_functionality.clar'
 clarity_version = 2

--- a/verbose_contracts/contracts/immutable_storage.clar
+++ b/verbose_contracts/contracts/immutable_storage.clar
@@ -1,0 +1,260 @@
+;; Enhanced Immutable Storage Contract
+;; This contract allows storing multiple types of immutable data with metadata and access controls
+
+;; Data Variables
+(define-data-var stored-value (optional uint) none)
+(define-data-var stored-string (optional (string-ascii 256)) none)
+(define-data-var stored-boolean (optional bool) none)
+(define-data-var is-value-set bool false)
+(define-data-var is-string-set bool false)
+(define-data-var is-boolean-set bool false)
+(define-data-var contract-owner principal tx-sender)
+(define-data-var creation-timestamp uint block-height)
+(define-data-var value-set-timestamp (optional uint) none)
+(define-data-var total-storage-operations uint u0)
+
+;; Maps for multiple key-value storage
+(define-map immutable-data 
+  { key: (string-ascii 64) }
+  { 
+    value: (string-ascii 512),
+    setter: principal,
+    timestamp: uint,
+    is-locked: bool
+  }
+)
+
+;; Map to track authorized setters
+(define-map authorized-setters principal bool)
+
+;; Error Constants
+(define-constant ERR-VALUE-ALREADY-SET (err u100))
+(define-constant ERR-UNAUTHORIZED (err u101))
+(define-constant ERR-KEY-ALREADY-EXISTS (err u102))
+(define-constant ERR-KEY-NOT-FOUND (err u103))
+(define-constant ERR-INVALID-INPUT (err u104))
+(define-constant ERR-STRING-TOO-LONG (err u105))
+
+;; Public Functions
+
+;; Store a uint value (can only be called once)
+(define-public (store-value (value uint))
+  (begin
+    (asserts! (is-eq (var-get is-value-set) false) ERR-VALUE-ALREADY-SET)
+    (asserts! (> value u0) ERR-INVALID-INPUT)
+    
+    (var-set stored-value (some value))
+    (var-set is-value-set true)
+    (var-set value-set-timestamp (some block-height))
+    (var-set total-storage-operations (+ (var-get total-storage-operations) u1))
+    
+    (print { event: "value-stored", value: value, setter: tx-sender, timestamp: block-height })
+    (ok value)
+  )
+)
+
+;; Store a string value (can only be called once)
+(define-public (store-string (value (string-ascii 256)))
+  (begin
+    (asserts! (is-eq (var-get is-string-set) false) ERR-VALUE-ALREADY-SET)
+    (asserts! (> (len value) u0) ERR-INVALID-INPUT)
+    
+    (var-set stored-string (some value))
+    (var-set is-string-set true)
+    (var-set total-storage-operations (+ (var-get total-storage-operations) u1))
+    
+    (print { event: "string-stored", value: value, setter: tx-sender, timestamp: block-height })
+    (ok value)
+  )
+)
+
+;; Store a boolean value (can only be called once)
+(define-public (store-boolean (value bool))
+  (begin
+    (asserts! (is-eq (var-get is-boolean-set) false) ERR-VALUE-ALREADY-SET)
+    
+    (var-set stored-boolean (some value))
+    (var-set is-boolean-set true)
+    (var-set total-storage-operations (+ (var-get total-storage-operations) u1))
+    
+    (print { event: "boolean-stored", value: value, setter: tx-sender, timestamp: block-height })
+    (ok value)
+  )
+)
+
+;; Store key-value pair (immutable once set)
+(define-public (store-data (key (string-ascii 64)) (value (string-ascii 512)))
+  (begin
+    (asserts! (> (len key) u0) ERR-INVALID-INPUT)
+    (asserts! (> (len value) u0) ERR-INVALID-INPUT)
+    (asserts! (is-none (map-get? immutable-data { key: key })) ERR-KEY-ALREADY-EXISTS)
+    
+    (map-set immutable-data 
+      { key: key }
+      {
+        value: value,
+        setter: tx-sender,
+        timestamp: block-height,
+        is-locked: true
+      }
+    )
+    
+    (var-set total-storage-operations (+ (var-get total-storage-operations) u1))
+    (print { event: "data-stored", key: key, value: value, setter: tx-sender })
+    (ok true)
+  )
+)
+
+;; Authorize a principal to store data (only owner)
+(define-public (authorize-setter (setter principal))
+  (begin
+    (asserts! (is-eq tx-sender (var-get contract-owner)) ERR-UNAUTHORIZED)
+    (map-set authorized-setters setter true)
+    (print { event: "setter-authorized", setter: setter, by: tx-sender })
+    (ok true)
+  )
+)
+
+;; Revoke authorization (only owner)
+(define-public (revoke-setter (setter principal))
+  (begin
+    (asserts! (is-eq tx-sender (var-get contract-owner)) ERR-UNAUTHORIZED)
+    (map-delete authorized-setters setter)
+    (print { event: "setter-revoked", setter: setter, by: tx-sender })
+    (ok true)
+  )
+)
+
+;; Store data with authorization check
+(define-public (store-authorized-data (key (string-ascii 64)) (value (string-ascii 512)))
+  (begin
+    (asserts! (or 
+      (is-eq tx-sender (var-get contract-owner))
+      (default-to false (map-get? authorized-setters tx-sender))
+    ) ERR-UNAUTHORIZED)
+    (asserts! (> (len key) u0) ERR-INVALID-INPUT)
+    (asserts! (> (len value) u0) ERR-INVALID-INPUT)
+    (asserts! (is-none (map-get? immutable-data { key: key })) ERR-KEY-ALREADY-EXISTS)
+    
+    (map-set immutable-data 
+      { key: key }
+      {
+        value: value,
+        setter: tx-sender,
+        timestamp: block-height,
+        is-locked: true
+      }
+    )
+    
+    (var-set total-storage-operations (+ (var-get total-storage-operations) u1))
+    (print { event: "authorized-data-stored", key: key, value: value, setter: tx-sender })
+    (ok true)
+  )
+)
+
+;; Read-only Functions
+
+;; Get the stored uint value
+(define-read-only (get-stored-value)
+  (var-get stored-value)
+)
+
+;; Get the stored string value
+(define-read-only (get-stored-string)
+  (var-get stored-string)
+)
+
+;; Get the stored boolean value
+(define-read-only (get-stored-boolean)
+  (var-get stored-boolean)
+)
+
+;; Get data by key
+(define-read-only (get-data (key (string-ascii 64)))
+  (map-get? immutable-data { key: key })
+)
+
+;; Get just the value by key
+(define-read-only (get-data-value (key (string-ascii 64)))
+  (match (map-get? immutable-data { key: key })
+    data (some (get value data))
+    none
+  )
+)
+
+;; Check if any value type has been set
+(define-read-only (is-any-value-set)
+  (or 
+    (var-get is-value-set)
+    (or (var-get is-string-set) (var-get is-boolean-set))
+  )
+)
+
+;; Check specific value type initialization
+(define-read-only (get-initialization-status)
+  {
+    uint-set: (var-get is-value-set),
+    string-set: (var-get is-string-set),
+    boolean-set: (var-get is-boolean-set)
+  }
+)
+
+;; Get contract metadata
+(define-read-only (get-contract-info)
+  {
+    owner: (var-get contract-owner),
+    creation-timestamp: (var-get creation-timestamp),
+    value-set-timestamp: (var-get value-set-timestamp),
+    total-operations: (var-get total-storage-operations)
+  }
+)
+
+;; Check if principal is authorized
+(define-read-only (is-authorized-setter (setter principal))
+  (or 
+    (is-eq setter (var-get contract-owner))
+    (default-to false (map-get? authorized-setters setter))
+  )
+)
+
+;; Get value with default fallback
+(define-read-only (get-value-or-default (default uint))
+  (match (var-get stored-value)
+    value value
+    default
+  )
+)
+
+;; Get string with default fallback
+(define-read-only (get-string-or-default (default (string-ascii 256)))
+  (match (var-get stored-string)
+    value value
+    default
+  )
+)
+
+;; Utility function to check if key exists
+(define-read-only (key-exists (key (string-ascii 64)))
+  (is-some (map-get? immutable-data { key: key }))
+)
+
+;; Get multiple values at once
+(define-read-only (get-all-primary-values)
+  {
+    uint-value: (var-get stored-value),
+    string-value: (var-get stored-string),
+    boolean-value: (var-get stored-boolean)
+  }
+)
+
+;; Validation function for data integrity
+(define-read-only (validate-storage-state)
+  {
+    consistent: (is-eq 
+      (var-get is-value-set) 
+      (is-some (var-get stored-value))
+    ),
+    total-operations: (var-get total-storage-operations),
+    contract-age: (- block-height (var-get creation-timestamp))
+  }
+)

--- a/verbose_contracts/tests/immutable_storage.test.ts
+++ b/verbose_contracts/tests/immutable_storage.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body>
<hr>

# 🧱 Enhanced Immutable Storage Contract

A **Clarity smart contract** for the **Stacks blockchain** that provides **immutable data storage** with **metadata**, **access control**, and **data integrity validation**.
Once values are written, they cannot be modified — ensuring **permanent, auditable, and tamper-proof storage** for decentralized applications.

---

## 📜 Overview

This contract allows users and authorized principals to **store different types of immutable data** (numbers, strings, booleans, and key-value pairs).
It is designed for use cases such as:

* On-chain record keeping
* Decentralized metadata storage
* Audit trails or compliance logs
* Certificate and identity registries
* DAO and governance archives

---

## ⚙️ Key Features

| Feature                       | Description                                                              |
| ----------------------------- | ------------------------------------------------------------------------ |
| 🧩 **Immutable Data Storage** | Once stored, data cannot be changed — only read.                         |
| 🧠 **Multiple Data Types**    | Supports storing `uint`, `string-ascii`, and `bool` values individually. |
| 🗝️ **Key-Value Storage**     | Allows adding arbitrary immutable key-value pairs with metadata.         |
| 👑 **Access Control**         | Contract owner can authorize or revoke other setters.                    |
| 🧾 **Metadata Tracking**      | Automatically records timestamps, setter, and total operations.          |
| 🛡️ **Integrity Validation**  | Built-in read-only checks to ensure data consistency.                    |
| 🧮 **Comprehensive Getters**  | Query individual data, all values, or fallback defaults safely.          |

---

## 🧰 Data Architecture

### **Global Data Variables**

| Variable                                          | Type                            | Description                                    |
| ------------------------------------------------- | ------------------------------- | ---------------------------------------------- |
| `stored-value`                                    | `(optional uint)`               | Immutable numeric value.                       |
| `stored-string`                                   | `(optional (string-ascii 256))` | Immutable text value.                          |
| `stored-boolean`                                  | `(optional bool)`               | Immutable boolean value.                       |
| `is-value-set`, `is-string-set`, `is-boolean-set` | `bool`                          | Tracks whether each type has been initialized. |
| `contract-owner`                                  | `principal`                     | Creator of the contract (immutable owner).     |
| `creation-timestamp`                              | `uint`                          | Block height at contract creation.             |
| `value-set-timestamp`                             | `(optional uint)`               | Timestamp of first uint storage.               |
| `total-storage-operations`                        | `uint`                          | Count of all successful write operations.      |

---

### **Maps**

| Map                  | Key                          | Value                                     | Description                                        |
| -------------------- | ---------------------------- | ----------------------------------------- | -------------------------------------------------- |
| `immutable-data`     | `{ key: (string-ascii 64) }` | `{ value, setter, timestamp, is-locked }` | Stores permanent key-value pairs with metadata.    |
| `authorized-setters` | `principal`                  | `bool`                                    | Maintains list of addresses allowed to store data. |

---

## 🚀 Public Functions

### 🧱 **Primary Value Storage**

| Function                                    | Description                                   |
| ------------------------------------------- | --------------------------------------------- |
| `(store-value (value uint))`                | Stores a single unsigned integer (only once). |
| `(store-string (value (string-ascii 256)))` | Stores a string (only once).                  |
| `(store-boolean (value bool))`              | Stores a boolean (only once).                 |

**Notes:**

* Each can be called **only once per contract lifetime**.
* Subsequent attempts return `ERR-VALUE-ALREADY-SET`.
* All operations emit events and increment operation counters.

---

### 🔐 **Immutable Key-Value Storage**

| Function                                                                     | Description                                              |
| ---------------------------------------------------------------------------- | -------------------------------------------------------- |
| `(store-data (key (string-ascii 64)) (value (string-ascii 512)))`            | Stores a new immutable key-value pair.                   |
| `(store-authorized-data (key (string-ascii 64)) (value (string-ascii 512)))` | Allows authorized principals or the owner to store data. |

**Behavior:**

* Keys are permanent — cannot be overwritten.
* Automatically locks each entry after creation.
* Emits an event `{ event: "data-stored", key, value, setter }`.

---

### 🧑‍💼 **Access Management**

| Function                                | Description                                      |
| --------------------------------------- | ------------------------------------------------ |
| `(authorize-setter (setter principal))` | Grants permission to a principal (owner only).   |
| `(revoke-setter (setter principal))`    | Removes a principal’s write access (owner only). |

---

## 🔍 Read-Only Functions

### 📦 **Data Retrieval**

| Function                                   | Description                                          |
| ------------------------------------------ | ---------------------------------------------------- |
| `(get-stored-value)`                       | Returns the stored uint (if any).                    |
| `(get-stored-string)`                      | Returns the stored string (if any).                  |
| `(get-stored-boolean)`                     | Returns the stored boolean (if any).                 |
| `(get-data (key (string-ascii 64)))`       | Returns all metadata for a given key.                |
| `(get-data-value (key (string-ascii 64)))` | Returns just the value of a given key.               |
| `(get-all-primary-values)`                 | Returns all three primary stored values in one call. |

---

### 🧭 **State and Status**

| Function                                    | Description                                                                     |
| ------------------------------------------- | ------------------------------------------------------------------------------- |
| `(is-any-value-set)`                        | Checks if any of the primary types (uint, string, bool) has been set.           |
| `(get-initialization-status)`               | Returns `{ uint-set, string-set, boolean-set }` flags.                          |
| `(get-contract-info)`                       | Returns `{ owner, creation-timestamp, value-set-timestamp, total-operations }`. |
| `(is-authorized-setter (setter principal))` | Checks if a principal can write data.                                           |
| `(key-exists (key (string-ascii 64)))`      | Checks if a key is already registered.                                          |

---

### 🧩 **Defaults and Validation**

| Function                                               | Description                                                                                                  |
| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
| `(get-value-or-default (default uint))`                | Returns stored uint or fallback default.                                                                     |
| `(get-string-or-default (default (string-ascii 256)))` | Returns stored string or fallback default.                                                                   |
| `(validate-storage-state)`                             | Ensures consistency between flags and stored data; returns `{ consistent, total-operations, contract-age }`. |

---

## 🚫 Error Codes

| Constant                 | Code   | Meaning                                  |
| ------------------------ | ------ | ---------------------------------------- |
| `ERR-VALUE-ALREADY-SET`  | `u100` | Attempted to overwrite immutable value.  |
| `ERR-UNAUTHORIZED`       | `u101` | Caller lacks permission.                 |
| `ERR-KEY-ALREADY-EXISTS` | `u102` | Key already present in `immutable-data`. |
| `ERR-KEY-NOT-FOUND`      | `u103` | Requested key not found.                 |
| `ERR-INVALID-INPUT`      | `u104` | Input cannot be empty or zero.           |
| `ERR-STRING-TOO-LONG`    | `u105` | String exceeds character limit.          |

---

## 🧾 Event Emissions

All write operations emit a printed event structure for auditability.

| Event Type                             | Example Fields                 |
| -------------------------------------- | ------------------------------ |
| `value-stored`                         | `{ value, setter, timestamp }` |
| `string-stored`                        | `{ value, setter, timestamp }` |
| `boolean-stored`                       | `{ value, setter, timestamp }` |
| `data-stored`                          | `{ key, value, setter }`       |
| `authorized-data-stored`               | `{ key, value, setter }`       |
| `setter-authorized` / `setter-revoked` | `{ setter, by }`               |

---

## 🧠 Example Usage

### Store a Numeric Value

```clarity
(contract-call? .immutable-storage store-value u42)
```

### Store a String

```clarity
(contract-call? .immutable-storage store-string "Hello, Blockchain!")
```

### Add a Key-Value Pair

```clarity
(contract-call? .immutable-storage store-data "license-id" "ABC-123-XYZ")
```

### Authorize Another Address

```clarity
(contract-call? .immutable-storage authorize-setter 'ST2J...EXAMPLE)
```

### Retrieve Contract Info

```clarity
(contract-call? .immutable-storage get-contract-info)
```

---

## 🧩 Example Output

When a value is stored, the contract emits:

```clarity
{ event: "value-stored", value: u42, setter: 'ST3ABC...', timestamp: u12345 }
```

When retrieving metadata:

```clarity
(contract-call? .immutable-storage get-data "license-id")

;; Returns:
;; (some { value: "ABC-123-XYZ", setter: 'ST3ABC...', timestamp: u12345, is-locked: true })
```

---

## 🛠️ Developer Notes

* **Immutability** is enforced — values cannot be changed once written.
* All state changes are **logged via `print` events** for external indexing or analytics.
* The **owner** is set to `tx-sender` upon deployment.
* Best used for **data registry**, **record-keeping**, or **NFT metadata anchoring**.

---

## ⚖️ License

MIT License © 2025 — Free to use, modify, and redistribute with attribution.

---

